### PR TITLE
Merge the existing speed-ups.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ hs_err_pid*
 /project/target/
 /benchmarking/target/
 /implementations/target/
+
+*.sh

--- a/benchmarking/src/main/java/ru/ifmo/nds/jmh/DominanceHelperBenchmark.java
+++ b/benchmarking/src/main/java/ru/ifmo/nds/jmh/DominanceHelperBenchmark.java
@@ -1,0 +1,112 @@
+package ru.ifmo.nds.jmh;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import ru.ifmo.nds.util.DominanceHelper;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Timeout(time = 10)
+@Warmup(iterations = 10)
+@Measurement(iterations = 3)
+@Fork(value = 3)
+public class DominanceHelperBenchmark {
+    @Param(value = {"2", "5", "10", "20"})
+    private int size;
+
+    @Param(value = {"random", "leftDominates", "rightDominates", "equal"})
+    private String type;
+
+    private double[][][] instances;
+
+    @Setup
+    public void initialize() {
+        int nInstances = 1000;
+        instances = new double[nInstances][2][size];
+
+        Random random = new Random(size * 8235435177845322L + type.hashCode());
+        switch (type) {
+            case "random":
+                for (int i = 0; i < nInstances; ++i) {
+                    for (int j = 0; j < size; ++j) {
+                        instances[i][0][j] = random.nextDouble();
+                        instances[i][1][j] = random.nextDouble();
+                    }
+                }
+                break;
+            case "leftDominates":
+                for (int i = 0; i < nInstances; ++i) {
+                    int diffIndex = random.nextInt(size);
+                    for (int j = 0; j < size; ++j) {
+                        instances[i][0][j] = random.nextDouble();
+                        if (random.nextBoolean() || j == diffIndex) {
+                            instances[i][1][j] = instances[i][0][j];
+                        } else {
+                            instances[i][1][j] = instances[i][0][j] + random.nextDouble();
+                        }
+                    }
+                }
+                break;
+            case "rightDominates":
+                for (int i = 0; i < nInstances; ++i) {
+                    int diffIndex = random.nextInt(size);
+                    for (int j = 0; j < size; ++j) {
+                        instances[i][0][j] = random.nextDouble();
+                        if (random.nextBoolean() || j == diffIndex) {
+                            instances[i][1][j] = instances[i][0][j];
+                        } else {
+                            instances[i][1][j] = instances[i][0][j] - random.nextDouble();
+                        }
+                    }
+                }
+                break;
+            case "equal":
+                for (int i = 0; i < nInstances; ++i) {
+                    for (int j = 0; j < size; ++j) {
+                        instances[i][0][j] = instances[i][1][j] = random.nextDouble();
+                    }
+                }
+                break;
+        }
+    }
+
+    @Benchmark
+    public void dominanceComparison1(Blackhole bh) {
+        for (double[][] instance : instances) {
+            bh.consume(DominanceHelper.dominanceComparison1(instance[0], instance[1], size));
+        }
+    }
+
+    @Benchmark
+    public void dominanceComparison2(Blackhole bh) {
+        for (double[][] instance : instances) {
+            bh.consume(DominanceHelper.dominanceComparison2(instance[0], instance[1], size));
+        }
+    }
+
+    @Benchmark
+    public void strictlyDominates1(Blackhole bh) {
+        for (double[][] instance : instances) {
+            bh.consume(DominanceHelper.strictlyDominates1(instance[0], instance[1], size));
+        }
+    }
+
+    @Benchmark
+    public void strictlyDominates2(Blackhole bh) {
+        for (double[][] instance : instances) {
+            bh.consume(DominanceHelper.strictlyDominates2(instance[0], instance[1], size));
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        new Runner(new OptionsBuilder().include(DominanceHelperBenchmark.class.getSimpleName()).build()).run();
+    }
+}

--- a/benchmarking/src/main/java/ru/ifmo/nds/jmh/DominanceHelperBenchmark.java
+++ b/benchmarking/src/main/java/ru/ifmo/nds/jmh/DominanceHelperBenchmark.java
@@ -15,7 +15,7 @@ import ru.ifmo.nds.util.DominanceHelper;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Timeout(time = 10)
-@Warmup(iterations = 10)
+@Warmup(iterations = 4)
 @Measurement(iterations = 3)
 @Fork(value = 3)
 public class DominanceHelperBenchmark {
@@ -59,11 +59,11 @@ public class DominanceHelperBenchmark {
                 for (int i = 0; i < nInstances; ++i) {
                     int diffIndex = random.nextInt(size);
                     for (int j = 0; j < size; ++j) {
-                        instances[i][0][j] = random.nextDouble();
+                        instances[i][1][j] = random.nextDouble();
                         if (random.nextBoolean() || j == diffIndex) {
-                            instances[i][1][j] = instances[i][0][j];
+                            instances[i][0][j] = instances[i][1][j];
                         } else {
-                            instances[i][1][j] = instances[i][0][j] - random.nextDouble();
+                            instances[i][0][j] = instances[i][1][j] + random.nextDouble();
                         }
                     }
                 }
@@ -79,30 +79,16 @@ public class DominanceHelperBenchmark {
     }
 
     @Benchmark
-    public void dominanceComparison1(Blackhole bh) {
+    public void dominanceComparison(Blackhole bh) {
         for (double[][] instance : instances) {
-            bh.consume(DominanceHelper.dominanceComparison1(instance[0], instance[1], size));
+            bh.consume(DominanceHelper.dominanceComparison(instance[0], instance[1], size));
         }
     }
 
     @Benchmark
-    public void dominanceComparison2(Blackhole bh) {
+    public void strictlyDominates(Blackhole bh) {
         for (double[][] instance : instances) {
-            bh.consume(DominanceHelper.dominanceComparison2(instance[0], instance[1], size));
-        }
-    }
-
-    @Benchmark
-    public void strictlyDominates1(Blackhole bh) {
-        for (double[][] instance : instances) {
-            bh.consume(DominanceHelper.strictlyDominates1(instance[0], instance[1], size));
-        }
-    }
-
-    @Benchmark
-    public void strictlyDominates2(Blackhole bh) {
-        for (double[][] instance : instances) {
-            bh.consume(DominanceHelper.strictlyDominates2(instance[0], instance[1], size));
+            bh.consume(DominanceHelper.strictlyDominates(instance[0], instance[1], size));
         }
     }
 

--- a/benchmarking/src/main/java/ru/ifmo/nds/jmh/MedianBenchmark.java
+++ b/benchmarking/src/main/java/ru/ifmo/nds/jmh/MedianBenchmark.java
@@ -30,7 +30,7 @@ public class MedianBenchmark {
     private double[][] data;
     private double[] temp;
 
-    @Setup(Level.Invocation)
+    @Setup
     public void initialize() {
         Random random = new Random(size * 723525217);
         data = new double[10][size];

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENSBase.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENSBase.java
@@ -33,6 +33,19 @@ public abstract class ENSBase extends NonDominatedSorting {
         return frontDominatesWithWork(frontIndex, points, point) >= 0;
     }
 
+    int findRankByBinarySearch(double[][] points, double[] point, int minRank, int maxRank) {
+        int leftRank = minRank, rightRank = maxRank + 1;
+        while (rightRank - leftRank > 1) {
+            int currRank = (leftRank + rightRank) >>> 1;
+            if (frontDominates(currRank, points, point)) {
+                leftRank = currRank;
+            } else {
+                rightRank = currRank;
+            }
+        }
+        return rightRank;
+    }
+
     int frontDominatesWithWork(int frontIndex, double[][] points, double[] point) {
         int index = lastRankIndex[frontIndex];
         int dim = point.length;

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENSBase.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENSBase.java
@@ -1,11 +1,10 @@
 package ru.ifmo.nds.ens;
 
+import java.util.Arrays;
+
 import ru.ifmo.nds.NonDominatedSorting;
 import ru.ifmo.nds.util.ArrayHelper;
-import ru.ifmo.nds.util.DominanceHelper;
 import ru.ifmo.nds.util.DoubleArraySorter;
-
-import java.util.Arrays;
 
 public abstract class ENSBase extends NonDominatedSorting {
     int[] indices;
@@ -46,17 +45,26 @@ public abstract class ENSBase extends NonDominatedSorting {
         return rightRank;
     }
 
+    private boolean strictlyDominatesAssumingNotSame(double[] good, double[] weak, int dim) {
+        for (int i = dim - 1; i > 0; --i) {
+            if (good[i] > weak[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     int frontDominatesWithWork(int frontIndex, double[][] points, double[] point) {
         int index = lastRankIndex[frontIndex];
         int dim = point.length;
         if (dim == 2) {
             // This is essentially how the 2D case of JFB works.
-            return DominanceHelper.strictlyDominates(points[index], point, dim) ? 1 : -1;
+            return strictlyDominatesAssumingNotSame(points[index], point, dim) ? 1 : -1;
         } else {
             int count = 0;
             while (index >= 0) {
                 ++count;
-                if (DominanceHelper.strictlyDominates(points[index], point, dim)) {
+                if (strictlyDominatesAssumingNotSame(points[index], point, dim)) {
                     return count;
                 }
                 index = prevIndex[index];

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENS_BS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENS_BS.java
@@ -5,27 +5,13 @@ public class ENS_BS extends ENSBase {
         super(maximumPoints, maximumDimension);
     }
 
-    private int findRank(double[][] points, int index, int maxRank) {
-        double[] point = points[index];
-        int leftRank = -1, rightRank = maxRank + 1;
-        while (rightRank - leftRank > 1) {
-            int currRank = (leftRank + rightRank) >>> 1;
-            if (frontDominates(currRank, points, point)) {
-                leftRank = currRank;
-            } else {
-                rightRank = currRank;
-            }
-        }
-        return rightRank;
-    }
-
     @Override
     void sortCheckedImpl(double[][] points, int[] ranks, int maximalMeaningfulRank) {
         int n = ranks.length;
         int maxRank = -1;
         for (int i = 0; i < n; ++i) {
             int index = indices[i];
-            int rank = findRank(points, index, maxRank);
+            int rank = findRankByBinarySearch(points, points[index], -1, maxRank);
             maxRank = setRank(index, ranks, rank, maxRank, maximalMeaningfulRank);
         }
     }

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENS_BS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENS_BS.java
@@ -15,7 +15,7 @@ public class ENS_BS extends ENSBase {
         int prevRank = -1;
         for (int i = 0; i < n; ++i) {
             int index = indices[i];
-            double[] curr = points[indices[i]];
+            double[] curr = points[index];
             int currRank;
             if (prev != null && ArrayHelper.equal(prev, curr)) {
                 currRank = prevRank;

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENS_BS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENS_BS.java
@@ -1,5 +1,7 @@
 package ru.ifmo.nds.ens;
 
+import ru.ifmo.nds.util.ArrayHelper;
+
 public class ENS_BS extends ENSBase {
     public ENS_BS(int maximumPoints, int maximumDimension) {
         super(maximumPoints, maximumDimension);
@@ -9,10 +11,19 @@ public class ENS_BS extends ENSBase {
     void sortCheckedImpl(double[][] points, int[] ranks, int maximalMeaningfulRank) {
         int n = ranks.length;
         int maxRank = -1;
+        double[] prev = null;
+        int prevRank = -1;
         for (int i = 0; i < n; ++i) {
             int index = indices[i];
-            int rank = findRankByBinarySearch(points, points[index], -1, maxRank);
-            maxRank = setRank(index, ranks, rank, maxRank, maximalMeaningfulRank);
+            double[] curr = points[indices[i]];
+            int currRank;
+            if (prev != null && ArrayHelper.equal(prev, curr)) {
+                currRank = prevRank;
+            } else {
+                prevRank = currRank = findRankByBinarySearch(points, curr, -1, maxRank);
+                prev = curr;
+            }
+            maxRank = setRank(index, ranks, currRank, maxRank, maximalMeaningfulRank);
         }
     }
 

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENS_HS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENS_HS.java
@@ -2,6 +2,8 @@ package ru.ifmo.nds.ens;
 
 import java.util.Arrays;
 
+import ru.ifmo.nds.util.ArrayHelper;
+
 public class ENS_HS extends ENSBase {
     private final int[] weights;
     private int weightSum;
@@ -11,8 +13,7 @@ public class ENS_HS extends ENSBase {
         weights = new int[maximumPoints];
     }
 
-    private int findRank(double[][] points, int index, int maxRank) {
-        double[] point = points[index];
+    private int findRank(double[][] points, double[] point, int maxRank) {
         if (point.length == 2) {
             return findRankByBinarySearch(points, point, -1, maxRank);
         }
@@ -42,14 +43,23 @@ public class ENS_HS extends ENSBase {
     void sortCheckedImpl(double[][] points, int[] ranks, int maximalMeaningfulRank) {
         int n = ranks.length;
         int maxRank = -1;
+        double[] prev = null;
+        int prevRank = -1;
         for (int i = 0; i < n; ++i) {
             int index = indices[i];
-            int rank = findRank(points, index, maxRank);
-            if (rank <= maximalMeaningfulRank) {
-                ++weights[rank];
-                ++weightSum;
+            double[] curr = points[indices[i]];
+            int currRank;
+            if (prev != null && ArrayHelper.equal(prev, curr)) {
+                currRank = prevRank;
+            } else {
+                prevRank = currRank = findRank(points, curr, maxRank);
+                prev = curr;
+                if (currRank <= maximalMeaningfulRank) {
+                    ++weights[currRank];
+                    ++weightSum;
+                }
             }
-            maxRank = setRank(index, ranks, rank, maxRank, maximalMeaningfulRank);
+            maxRank = setRank(index, ranks, currRank, maxRank, maximalMeaningfulRank);
         }
         weightSum = 0;
         Arrays.fill(weights, 0, maxRank + 1, 0);

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENS_HS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENS_HS.java
@@ -11,19 +11,6 @@ public class ENS_HS extends ENSBase {
         weights = new int[maximumPoints];
     }
 
-    private int findRankByBinarySearch(double[][] points, double[] point, int minRank, int maxRank) {
-        int leftRank = minRank, rightRank = maxRank + 1;
-        while (rightRank - leftRank > 1) {
-            int currRank = (leftRank + rightRank) >>> 1;
-            if (frontDominates(currRank, points, point)) {
-                leftRank = currRank;
-            } else {
-                rightRank = currRank;
-            }
-        }
-        return rightRank;
-    }
-
     private int findRank(double[][] points, int index, int maxRank) {
         double[] point = points[index];
         if (point.length == 2) {

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENS_HS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENS_HS.java
@@ -26,14 +26,16 @@ public class ENS_HS extends ENSBase {
             if (query < 0) {
                 return rank;
             }
-            totalWork += query;
-            remainingN -= weights[rank];
-            --remainingRanks;
-            if (remainingRanks < (1 << logRemainingRanks)) {
-                --logRemainingRanks;
-            }
-            if ((long) (totalWork) * remainingRanks > (long) (remainingN) * logRemainingRanks) {
-                return findRankByBinarySearch(points, point, rank, maxRank);
+            if (rank < maxRank) {
+                totalWork += query;
+                remainingN -= weights[rank];
+                --remainingRanks;
+                if (remainingRanks < (1 << logRemainingRanks)) {
+                    --logRemainingRanks;
+                }
+                if ((long) (totalWork) * remainingRanks > (long) (remainingN) * logRemainingRanks) {
+                    return findRankByBinarySearch(points, point, rank, maxRank);
+                }
             }
         }
         return maxRank + 1;

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENS_HS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENS_HS.java
@@ -47,7 +47,7 @@ public class ENS_HS extends ENSBase {
         int prevRank = -1;
         for (int i = 0; i < n; ++i) {
             int index = indices[i];
-            double[] curr = points[indices[i]];
+            double[] curr = points[index];
             int currRank;
             if (prev != null && ArrayHelper.equal(prev, curr)) {
                 currRank = prevRank;

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENS_SS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENS_SS.java
@@ -1,12 +1,13 @@
 package ru.ifmo.nds.ens;
 
+import ru.ifmo.nds.util.ArrayHelper;
+
 public class ENS_SS extends ENSBase {
     public ENS_SS(int maximumPoints, int maximumDimension) {
         super(maximumPoints, maximumDimension);
     }
 
-    private int findRank(double[][] points, int index, int maxRank) {
-        double[] point = points[index];
+    private int findRank(double[][] points, double[] point, int maxRank) {
         int currRank = 0;
         while (currRank <= maxRank) {
             if (frontDominates(currRank, points, point)) {
@@ -22,9 +23,18 @@ public class ENS_SS extends ENSBase {
     void sortCheckedImpl(double[][] points, int[] ranks, int maximalMeaningfulRank) {
         int n = ranks.length;
         int maxRank = -1;
+        double[] prev = null;
+        int prevRank = -1;
         for (int i = 0; i < n; ++i) {
             int index = indices[i];
-            int currRank = findRank(points, index, maxRank);
+            double[] curr = points[indices[i]];
+            int currRank;
+            if (prev != null && ArrayHelper.equal(prev, curr)) {
+                currRank = prevRank;
+            } else {
+                prevRank = currRank = findRank(points, curr, maxRank);
+                prev = curr;
+            }
             maxRank = setRank(index, ranks, currRank, maxRank, maximalMeaningfulRank);
         }
     }

--- a/implementations/src/main/java/ru/ifmo/nds/ens/ENS_SS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/ens/ENS_SS.java
@@ -27,7 +27,7 @@ public class ENS_SS extends ENSBase {
         int prevRank = -1;
         for (int i = 0; i < n; ++i) {
             int index = indices[i];
-            double[] curr = points[indices[i]];
+            double[] curr = points[index];
             int currRank;
             if (prev != null && ArrayHelper.equal(prev, curr)) {
                 currRank = prevRank;

--- a/implementations/src/main/java/ru/ifmo/nds/jfb/AbstractJFBSorting.java
+++ b/implementations/src/main/java/ru/ifmo/nds/jfb/AbstractJFBSorting.java
@@ -338,19 +338,25 @@ public abstract class AbstractJFBSorting extends NonDominatedSorting {
         int weakMidR = SplitMergeHelper.extractRight(weakSplit);
         int tempMid = tempFrom + ((goodUntil - goodFrom + weakUntil - weakFrom) >>> 1);
 
+        int newWeakUntil = helperB(goodFrom, goodMidL, weakMidR, weakUntil, obj - 1, tempFrom);
+        newWeakUntil = helperB(goodMidL, goodMidR, weakMidR, newWeakUntil, obj - 1, tempFrom);
+
+        int newWeakMidR = helperB(goodFrom, goodMidL, weakMidL, weakMidR, obj - 1, tempFrom);
+        newWeakMidR = helperB(goodMidL, goodMidR, weakMidL, newWeakMidR, obj - 1, tempFrom);
+
         ForkJoinTask<Integer> newWeakMidLTask = null;
         if (pool != null && goodMidL - goodFrom + weakMidL - weakFrom > FORK_JOIN_THRESHOLD) {
             newWeakMidLTask = helperBAsync(goodFrom, goodMidL, weakFrom, weakMidL, obj, tempFrom).fork();
         }
-        int newWeakUntil = helperB(goodMidR, goodUntil, weakMidR, weakUntil, obj, tempMid);
+        newWeakUntil = helperB(goodMidR, goodUntil, weakMidR, newWeakUntil, obj, tempMid);
         int newWeakMidL = newWeakMidLTask != null
                 ? newWeakMidLTask.join()
                 : helperB(goodFrom, goodMidL, weakFrom, weakMidL, obj, tempFrom);
 
         splitMerge.mergeTwo(indices, tempFrom, goodFrom, goodMidL, goodMidL, goodMidR);
-        newWeakUntil = splitMerge.mergeTwo(indices, tempFrom, weakMidL, weakMidR, weakMidR, newWeakUntil);
-        newWeakUntil = helperB(goodFrom, goodMidR, weakMidL, newWeakUntil, obj - 1, tempFrom);
         splitMerge.mergeTwo(indices, tempFrom, goodFrom, goodMidR, goodMidR, goodUntil);
+
+        newWeakUntil = splitMerge.mergeTwo(indices, tempFrom, weakMidL, newWeakMidR, weakMidR, newWeakUntil);
         return splitMerge.mergeTwo(indices, tempFrom, weakFrom, newWeakMidL, weakMidL, newWeakUntil);
     }
 

--- a/implementations/src/main/java/ru/ifmo/nds/jfb/AbstractJFBSorting.java
+++ b/implementations/src/main/java/ru/ifmo/nds/jfb/AbstractJFBSorting.java
@@ -236,8 +236,7 @@ public abstract class AbstractJFBSorting extends NonDominatedSorting {
             newUntil = helperB(startMid, newStartRight, startRight, newUntil, obj - 1, from);
             newUntil = helperA(startRight, newUntil, obj);
 
-            newStartRight = splitMerge.mergeTwo(indices, from, from, newStartMid, startMid, newStartRight);
-            return splitMerge.mergeTwo(indices, from, from, newStartRight, startRight, newUntil);
+            return splitMerge.mergeThree(indices, from, from, newStartMid, startMid, newStartRight, startRight, newUntil);
         }
     }
 
@@ -355,11 +354,9 @@ public abstract class AbstractJFBSorting extends NonDominatedSorting {
                 ? newWeakMidLTask.join()
                 : helperB(goodFrom, goodMidL, weakFrom, weakMidL, obj, tempFrom);
 
-        splitMerge.mergeTwo(indices, tempFrom, goodFrom, goodMidL, goodMidL, goodMidR);
-        splitMerge.mergeTwo(indices, tempFrom, goodFrom, goodMidR, goodMidR, goodUntil);
-
-        newWeakUntil = splitMerge.mergeTwo(indices, tempFrom, weakMidL, newWeakMidR, weakMidR, newWeakUntil);
-        return splitMerge.mergeTwo(indices, tempFrom, weakFrom, newWeakMidL, weakMidL, newWeakUntil);
+        splitMerge.mergeThree(indices, tempFrom, goodFrom, goodMidL, goodMidL, goodMidR, goodMidR, goodUntil);
+        return splitMerge.mergeThree(indices, tempFrom,
+                weakFrom, newWeakMidL, weakMidL, newWeakMidR, weakMidR, newWeakUntil);
     }
 
     private RecursiveTask<Integer> helperBAsync(final int goodFrom, final int goodUntil,

--- a/implementations/src/main/java/ru/ifmo/nds/jfb/AbstractJFBSorting.java
+++ b/implementations/src/main/java/ru/ifmo/nds/jfb/AbstractJFBSorting.java
@@ -232,9 +232,11 @@ public abstract class AbstractJFBSorting extends NonDominatedSorting {
             int newStartMid = helperA(from, startMid, obj);
             int newStartRight = helperB(from, newStartMid, startMid, startRight, obj - 1, from);
             newStartRight = helperA(startMid, newStartRight, obj - 1);
-            newStartRight = splitMerge.mergeTwo(indices, from, from, newStartMid, startMid, newStartRight);
-            int newUntil = helperB(from, newStartRight, startRight, until, obj - 1, from);
+            int newUntil = helperB(from, newStartMid, startRight, until, obj - 1, from);
+            newUntil = helperB(startMid, newStartRight, startRight, newUntil, obj - 1, from);
             newUntil = helperA(startRight, newUntil, obj);
+
+            newStartRight = splitMerge.mergeTwo(indices, from, from, newStartMid, startMid, newStartRight);
             return splitMerge.mergeTwo(indices, from, from, newStartRight, startRight, newUntil);
         }
     }

--- a/implementations/src/main/java/ru/ifmo/nds/jfb/RedBlackTreeSweepHybridENS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/jfb/RedBlackTreeSweepHybridENS.java
@@ -232,19 +232,17 @@ public class RedBlackTreeSweepHybridENS extends RedBlackTreeSweep {
                 while (currSlice <= sliceLast) {
                     int from = space[currSlice];
                     int until = space[currSlice + 1];
-                    if (from == until) {
-                        currSlice += 2;
-                    } else {
+                    if (from < until) {
                         int currRank = ranks[space[until - 1]];
-                        if (currRank < weakRank) {
-                            currSlice += 2;
-                        } else if (checkWhetherDominates(space, from, until, wi, obj)) {
-                            currSlice += 2;
-                            weakRank = currRank + 1;
-                        } else {
-                            break;
+                        if (currRank >= weakRank) {
+                            if (checkWhetherDominates(space, from, until, wi, obj)) {
+                                weakRank = currRank + 1;
+                            } else {
+                                break;
+                            }
                         }
                     }
+                    currSlice += 2;
                 }
                 ranks[wi] = weakRank;
                 if (minOverflowed > weak && weakRank > maximalMeaningfulRank) {

--- a/implementations/src/main/java/ru/ifmo/nds/jfb/RedBlackTreeSweepHybridENS.java
+++ b/implementations/src/main/java/ru/ifmo/nds/jfb/RedBlackTreeSweepHybridENS.java
@@ -121,12 +121,12 @@ public class RedBlackTreeSweepHybridENS extends RedBlackTreeSweep {
         int left = from, right = to;
         int pivot = (space[space[from]] + space[space[to]]) / 2;
         while (left <= right) {
-            while (space[space[left]] < pivot) ++left;
-            while (space[space[right]] > pivot) --right;
+            int sl, sr;
+            while (space[sl = space[left]] < pivot) ++left;
+            while (space[sr = space[right]] > pivot) --right;
             if (left <= right) {
-                int tmp = space[left];
-                space[left] = space[right];
-                space[right] = tmp;
+                space[left] = sr;
+                space[right] = sl;
                 ++left;
                 --right;
             }
@@ -153,10 +153,13 @@ public class RedBlackTreeSweepHybridENS extends RedBlackTreeSweep {
         int minUpdated = weakUntil;
         for (int weak = weakFrom, good = goodFrom; weak < weakUntil; ++weak) {
             int wi = indices[weak];
+            if (ranks[wi] > rank) {
+                continue;
+            }
             while (good < goodUntil && indices[good] < wi) {
                 ++good;
             }
-            if (ranks[wi] <= rank && checkWhetherDominates(indices, goodFrom, good, wi, obj)) {
+            if (checkWhetherDominates(indices, goodFrom, good, wi, obj)) {
                 ranks[wi] = rank + 1;
                 minUpdated = weak;
             }
@@ -219,8 +222,9 @@ public class RedBlackTreeSweepHybridENS extends RedBlackTreeSweep {
                 int wi = indices[weak];
                 int gi;
                 while (good < goodUntil && (gi = indices[good]) < wi) {
-                    int sliceIndex = space[ranksAndSlicesOffset + good - goodFrom];
-                    space[space[sliceIndex + 1]++] = gi;
+                    int sliceTailIndex = space[ranksAndSlicesOffset + good - goodFrom] + 1;
+                    space[space[sliceTailIndex]] = gi;
+                    ++space[sliceTailIndex];
                     ++good;
                 }
                 int currSlice = sliceOffset;
@@ -231,7 +235,7 @@ public class RedBlackTreeSweepHybridENS extends RedBlackTreeSweep {
                     if (from == until) {
                         currSlice += 2;
                     } else {
-                        int currRank = ranks[space[from]];
+                        int currRank = ranks[space[until - 1]];
                         if (currRank < weakRank) {
                             currSlice += 2;
                         } else if (checkWhetherDominates(space, from, until, wi, obj)) {

--- a/implementations/src/main/java/ru/ifmo/nds/util/DominanceHelper.java
+++ b/implementations/src/main/java/ru/ifmo/nds/util/DominanceHelper.java
@@ -3,33 +3,74 @@ package ru.ifmo.nds.util;
 public final class DominanceHelper {
     private DominanceHelper() {}
 
-    private static final int HAS_LESS_MASK = 1;
-    private static final int HAS_GREATER_MASK = 2;
-
-    private static final int[] REINDEX = { 0, -1, 1, 0 };
-
     public static boolean strictlyDominates(double[] a, double[] b, int dim) {
-        return detailedDominanceComparison(a, b, dim, HAS_GREATER_MASK) == HAS_LESS_MASK;
+        return strictlyDominates1(a, b, dim);
     }
 
     public static int dominanceComparison(double[] a, double[] b, int dim) {
-        int rv = detailedDominanceComparison(a, b, dim, HAS_GREATER_MASK | HAS_LESS_MASK);
-        return REINDEX[rv];
+        return dominanceComparison1(a, b, dim);
     }
 
-    private static int detailedDominanceComparison(double[] a, double[] b, int dim, int breakMask) {
-        int result = 0;
+    public static boolean strictlyDominates1(double[] a, double[] b, int dim) {
+        boolean hasSmaller = false;
+        for (int i = 0; i < dim; ++i) {
+            double ai = a[i], bi = b[i];
+            if (ai > bi) {
+                return false;
+            }
+            if (ai < bi) {
+                hasSmaller = true;
+            }
+        }
+        return hasSmaller;
+    }
+
+    public static boolean strictlyDominates2(double[] a, double[] b, int dim) {
+        boolean hasSmaller = false;
+        for (int i = 0; i < dim; ++i) {
+            double ai = a[i], bi = b[i];
+            if (ai > bi) {
+                return false;
+            }
+            hasSmaller |= ai < bi;
+        }
+        return hasSmaller;
+    }
+
+    public static int dominanceComparison1(double[] a, double[] b, int dim) {
+        boolean hasSmaller = false;
+        boolean hasGreater = false;
         for (int i = 0; i < dim; ++i) {
             double ai = a[i], bi = b[i];
             if (ai < bi) {
-                result |= HAS_LESS_MASK;
+                if (hasGreater) {
+                    return 0;
+                }
+                hasSmaller = true;
             } else if (ai > bi) {
-                result |= HAS_GREATER_MASK;
-            }
-            if ((result & breakMask) == breakMask) {
-                break;
+                if (hasSmaller) {
+                    return 0;
+                }
+                hasGreater = true;
             }
         }
-        return result;
+        return hasSmaller ? -1 : hasGreater ? 1 : 0;
+    }
+
+    public static int dominanceComparison2(double[] a, double[] b, int dim) {
+        boolean hasSmaller = false;
+        boolean hasGreater = false;
+        for (int i = 0; i < dim; ++i) {
+            double ai = a[i], bi = b[i];
+            if (ai < bi) {
+                hasSmaller = true;
+            } else if (ai > bi) {
+                hasGreater = true;
+            }
+            if (hasSmaller && hasGreater) {
+                return 0;
+            }
+        }
+        return hasSmaller ? -1 : hasGreater ? 1 : 0;
     }
 }

--- a/implementations/src/main/java/ru/ifmo/nds/util/DominanceHelper.java
+++ b/implementations/src/main/java/ru/ifmo/nds/util/DominanceHelper.java
@@ -4,67 +4,29 @@ public final class DominanceHelper {
     private DominanceHelper() {}
 
     public static boolean strictlyDominates(double[] a, double[] b, int dim) {
-        return strictlyDominates1(a, b, dim);
+        boolean hasSmaller = false;
+        for (int i = 0; i < dim; ++i) {
+            double ai = a[i], bi = b[i];
+            if (ai > bi) {
+                return false;
+            }
+            if (ai < bi) {
+                hasSmaller = true;
+            }
+        }
+        return hasSmaller;
     }
 
     public static int dominanceComparison(double[] a, double[] b, int dim) {
-        return dominanceComparison1(a, b, dim);
-    }
-
-    public static boolean strictlyDominates1(double[] a, double[] b, int dim) {
-        boolean hasSmaller = false;
-        for (int i = 0; i < dim; ++i) {
-            double ai = a[i], bi = b[i];
-            if (ai > bi) {
-                return false;
-            }
-            if (ai < bi) {
-                hasSmaller = true;
-            }
-        }
-        return hasSmaller;
-    }
-
-    public static boolean strictlyDominates2(double[] a, double[] b, int dim) {
-        boolean hasSmaller = false;
-        for (int i = 0; i < dim; ++i) {
-            double ai = a[i], bi = b[i];
-            if (ai > bi) {
-                return false;
-            }
-            hasSmaller |= ai < bi;
-        }
-        return hasSmaller;
-    }
-
-    public static int dominanceComparison1(double[] a, double[] b, int dim) {
-        boolean hasSmaller = false;
-        boolean hasGreater = false;
-        for (int i = 0; i < dim; ++i) {
-            double ai = a[i], bi = b[i];
-            if (ai < bi) {
-                if (hasGreater) {
-                    return 0;
-                }
-                hasSmaller = true;
-            } else if (ai > bi) {
-                if (hasSmaller) {
-                    return 0;
-                }
-                hasGreater = true;
-            }
-        }
-        return hasSmaller ? -1 : hasGreater ? 1 : 0;
-    }
-
-    public static int dominanceComparison2(double[] a, double[] b, int dim) {
         boolean hasSmaller = false;
         boolean hasGreater = false;
         for (int i = 0; i < dim; ++i) {
             double ai = a[i], bi = b[i];
             if (ai < bi) {
                 hasSmaller = true;
-            } else if (ai > bi) {
+            }
+            // no "else if" because the code becomes way slower on inputs where "a" dominates "b".
+            if (ai > bi) {
                 hasGreater = true;
             }
             if (hasSmaller && hasGreater) {

--- a/implementations/src/main/java/ru/ifmo/nds/util/SplitMergeHelper.java
+++ b/implementations/src/main/java/ru/ifmo/nds/util/SplitMergeHelper.java
@@ -23,9 +23,11 @@ public final class SplitMergeHelper {
                 int ii = indices[i];
                 double v = points[ii];
                 if (v < median || (equalToLeft && v == median)) {
-                    indices[left++] = ii;
+                    indices[left] = ii;
+                    ++left;
                 } else {
-                    scratchR[right++] = ii;
+                    scratchR[right] = ii;
+                    ++right;
                 }
             }
             System.arraycopy(scratchR, tempFrom, indices, left, right - tempFrom);
@@ -48,11 +50,14 @@ public final class SplitMergeHelper {
                 int ii = indices[i];
                 double v = points[ii];
                 if (v < median) {
-                    indices[l++] = ii;
+                    indices[l] = ii;
+                    ++l;
                 } else if (v == median) {
-                    scratchM[m++] = ii;
+                    scratchM[m] = ii;
+                    ++m;
                 } else {
-                    scratchR[r++] = ii;
+                    scratchR[r] = ii;
+                    ++r;
                 }
             }
             System.arraycopy(scratchM, tempFrom, indices, l, m - tempFrom);
@@ -64,11 +69,25 @@ public final class SplitMergeHelper {
     public final int mergeTwo(int[] indices, int tempFrom, int fromLeft, int untilLeft, int fromRight, int untilRight) {
         int target = tempFrom;
         int l = fromLeft, r = fromRight;
-        while (l < untilLeft && r < untilRight) {
-            if (indices[l] <= indices[r]) {
-                scratchM[target++] = indices[l++];
-            } else {
-                scratchM[target++] = indices[r++];
+        if (l < untilLeft && r < untilRight) {
+            int il = indices[l];
+            int ir = indices[r];
+            while (true) {
+                if (il <= ir) {
+                    scratchM[target] = il;
+                    ++target;
+                    if (++l == untilLeft) {
+                        break;
+                    }
+                    il = indices[l];
+                } else {
+                    scratchM[target] = ir;
+                    ++target;
+                    if (++r == untilRight) {
+                        break;
+                    }
+                    ir = indices[r];
+                }
             }
         }
         int newR = fromLeft + (target - tempFrom) + untilLeft - l;

--- a/implementations/src/main/java/ru/ifmo/nds/util/SplitMergeHelper.java
+++ b/implementations/src/main/java/ru/ifmo/nds/util/SplitMergeHelper.java
@@ -1,5 +1,7 @@
 package ru.ifmo.nds.util;
 
+import java.util.Arrays;
+
 public final class SplitMergeHelper {
     private final int[] scratchM, scratchR;
 
@@ -66,7 +68,21 @@ public final class SplitMergeHelper {
         }
     }
 
-    public final int mergeTwo(int[] indices, int tempFrom, int fromLeft, int untilLeft, int fromRight, int untilRight) {
+    public final int mergeThree(int[] indices, int tempFrom,
+                                int fromLeft, int untilLeft,
+                                int fromMid, int untilMid,
+                                int fromRight, int untilRight) {
+        if (fromMid != untilMid) {
+            untilLeft = mergeTwo(indices, tempFrom, fromLeft, untilLeft, fromMid, untilMid);
+        }
+        return mergeTwo(indices, tempFrom, fromLeft, untilLeft, fromRight, untilRight);
+    }
+
+    private int mergeTwo(int[] indices, int tempFrom, int fromLeft, int untilLeft, int fromRight, int untilRight) {
+        if (fromRight == untilRight) {
+            return untilLeft;
+        }
+        fromLeft = -Arrays.binarySearch(indices, fromLeft, untilLeft, indices[fromRight]) - 1;
         int target = tempFrom;
         int l = fromLeft, r = fromRight;
         if (l < untilLeft && r < untilRight) {


### PR DESCRIPTION
A short overview for what has been done here:

1) More efficient splits and merges.
2) Make helperB first do cross-comparisons then side-comparisons. This brings the monotonicity invariant back, which helps the hybrids to me more efficient.
3) A less cache-spoiling implementation of RedBlackTreeSweepHybridENS.
4) Some noticeable speed-ups in ENS-* algorithms.
5) A more accurate way to switch on the parallel computations in JFB that does not degrade on small instances.